### PR TITLE
Prefix "/" before getResource(..) to prevent MalformedURLException

### DIFF
--- a/src/main/java/org/graphity/client/provider/XSLTBuilderProvider.java
+++ b/src/main/java/org/graphity/client/provider/XSLTBuilderProvider.java
@@ -195,6 +195,7 @@ public class XSLTBuilderProvider extends PerRequestTypeInjectableProvider<Contex
     {
 	if (filename == null) throw new IllegalArgumentException("XML file name cannot be null");	
 	if (log.isDebugEnabled()) log.debug("Resource paths used to load Source: {} from filename: {}", getServletContext().getResourcePaths("/"), filename);
+	if (!filename.startsWith("/")) { filename = "/" + filename; }
         URL xsltUrl = getServletContext().getResource(filename);
 	if (xsltUrl == null) throw new FileNotFoundException("File '" + filename + "' not found");
 	String xsltUri = xsltUrl.toURI().toString();


### PR DESCRIPTION
I've got the following error on my first access to localhost:8080 :

```
Mapped exception to response: 500 (Internal Server Error)
javax.ws.rs.WebApplicationException: java.net.MalformedURLException: static/org/graphity/client/xsl/global-xhtml.xsl
        at org.graphity.client.provider.XSLTBuilderProvider.getXSLTBuilder(XSLTBuilderProvider.java:158)
        at org.graphity.client.provider.XSLTBuilderProvider.getContext(XSLTBuilderProvider.java:110)
        at org.graphity.client.provider.XSLTBuilderProvider.getContext(XSLTBuilderProvider.java:54)
...
Caused by: java.net.MalformedURLException: static/org/graphity/client/xsl/global-xhtml.xsl
        at org.eclipse.jetty.webapp.WebAppContext.getResource(WebAppContext.java:354)
        at org.eclipse.jetty.webapp.WebAppContext$Context.getResource(WebAppContext.java:1451)
        at org.graphity.client.provider.XSLTBuilderProvider.getSource(XSLTBuilderProvider.java:198)
        at org.graphity.client.provider.XSLTBuilderProvider.getSource(XSLTBuilderProvider.java:181)
        at org.graphity.client.provider.XSLTBuilderProvider.getXSLTBuilder(XSLTBuilderProvider.java:137)
```

(in Mac OS 10.10.1, Oracle JDK 8)

To resolve this error, I added the code that prefixes "/" to filename before calling [getResource(filename)](http://docs.oracle.com/javaee/6/api/javax/servlet/ServletContext.html#getResource(java.lang.String)).